### PR TITLE
✨ adds `bfsp use` sub command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,12 @@ npm i -g @bfchian/pkgm
    ```shell
    bfsp publ example-package --registry=http://localhost:4873 --version=0.0.1-alpha.1
    ```
+6. bfsp use packageName --version=x.x.x
+   > 设置项目下所有以`packageName`开头的依赖版本为`^x.x.x`
+   ```shell
+   bfsp use @bfs/core --version=0.0.1-alpha.1
+   ```
+   项目下所有bfsp.json文件内的dependencies中以`@bfs/core`开头的依赖都会被改成`^0.0.1-alpha.1`
+   
 ## License - 许可
 <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="知识共享许可协议" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a><br/>本作品采用 <a rel="license" href="https://creativecommons.org/licenses/by-na-sa/4.0/">知识共享署名-非商业性许可-相同方式共享 4.0 国际许可协议</a> 进行许可。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bfchain/pkgm",
-  "version": "0.0.1-alpha.6",
+  "version": "0.0.1-alpha.7",
   "description": "",
   "main": "build/index.js",
   "bin": {

--- a/src/bin/bfsp.ts
+++ b/src/bin/bfsp.ts
@@ -153,6 +153,33 @@ if (require.main === module) {
         publer.publish({ packageName, registry, version });
       }
       break;
+    case 'use':
+      {
+        let version = '';
+
+        let asString = (s: string | boolean) => s as string;
+        parseArgv(argv, [buildArgParserEmitter('version', asString, (v) => (version = v))]);
+
+        let packageName = argv.shift();
+        while (packageName?.startsWith('--')) {
+          packageName = argv.shift();
+        }
+        if (!packageName) {
+          throw new Error('package name is not specified');
+        }
+        console.log(`update version of deps prefixed with ${packageName} to ${version}`)
+        const bfsProject = BFSProject.from({ autoInit: false });
+        const publer = Publer.from(
+          {
+            bfsProject,
+          },
+          moduleMap
+        );
+        bfsProject.readAllProjectList().forEach((x) => {
+          publer.updateVersion(x, version, 'bfsp', packageName!, { self: false, deps: true });
+        });
+      }
+      break;
     default:
       console.error(`unknown cmd: '${cmd}'`);
   }


### PR DESCRIPTION
新增指令
bfsp use packageName --version=x.x.x
   > 设置项目下所有以`packageName`开头的依赖版本为`^x.x.x`
   ```shell
   bfsp use @bfs/core --version=0.0.1-alpha.1
   ```
   项目下所有bfsp.json文件内的dependencies中以`@bfs/core`开头的依赖都会被改成`^0.0.1-alpha.1`
   