### PR TITLE
🐛 update dep version of bfsp.json correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bfchain/pkgm",
-  "version": "0.0.1-alpha.7",
+  "version": "0.0.1-alpha.8",
   "description": "",
   "main": "build/index.js",
   "bin": {


### PR DESCRIPTION
正确设置bfsp.json的依赖版本，带版本名字例如@bfchain/util:^0.0.1和is-digit@0.0.1也能正确识别了